### PR TITLE
Get MathLive to load

### DIFF
--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -8,7 +8,7 @@
 
 <ion-content padding>
   The world is your oyster.
-  <div class="mathfield"  id='mathfield' >
+  <div class="mathfield"  #mathfield >
 
   </div>
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,7 +1,6 @@
 import { Component,  ElementRef, Input, ViewChild, Inject } from '@angular/core';
 import { NavController } from 'ionic-angular';
 import * as MathLive from 'mathlive';
-declare var MathLive;
 
 
 
@@ -13,7 +12,10 @@ export class HomePage {
 @ViewChild('mathfield') mathfield: ElementRef;
 
   constructor(public navCtrl: NavController, public el:ElementRef) {
-MathLive.makeMathField(this.mathfield.nativeElement);
+  }
+
+  ionViewDidLoad() {
+    MathLive.makeMathField(this.mathfield.nativeElement);
   }
 
 }


### PR DESCRIPTION
Two changes:
- Use the correct syntax in the <div> to declare the mathfield ID
- Use ionViewDidLoad to initialize the mathfield (when the constructor is called the DOM elements have not been instantiated yet)